### PR TITLE
Feature: Redesign the lobby screen

### DIFF
--- a/SwingUI/src/main/java/com/hawolt/ui/queue/DraftGameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/DraftGameLobby.java
@@ -12,7 +12,6 @@ import com.hawolt.logger.Logger;
 import com.hawolt.ui.generic.component.LComboBox;
 import com.hawolt.ui.generic.utility.ChildUIComponent;
 
-import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -34,8 +33,7 @@ public class DraftGameLobby extends GameLobby implements ActionListener {
 
     @Override
     protected void createSpecificComponents(ChildUIComponent component) {
-        ChildUIComponent roles = new ChildUIComponent(new GridLayout(0, 2, 5, 0));
-        roles.setBorder(new EmptyBorder(5, 5, 5, 5));
+        ChildUIComponent roles = new ChildUIComponent(new GridLayout(0, 2, 8, 0));
         main = new LComboBox<>(PositionPreference.values());
         main.addActionListener(this);
         roles.add(main);
@@ -48,9 +46,8 @@ public class DraftGameLobby extends GameLobby implements ActionListener {
 
     @Override
     protected void createGrid(ChildUIComponent component) {
-        grid = new ChildUIComponent(new GridLayout(1, 5));
+        grid = new ChildUIComponent(new GridLayout(1, 5, 4, 0));
         for (int i = 0; i < 5; i++) grid.add(new DraftSummonerComponent());
-        grid.setBackground(Color.YELLOW);
         component.add(grid, BorderLayout.CENTER);
     }
 

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/DraftSummonerComponent.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/DraftSummonerComponent.java
@@ -22,59 +22,37 @@ public class DraftSummonerComponent extends SummonerComponent {
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
+        Dimension dimensions = getSize();
+        Graphics2D g2d = (Graphics2D) g;
+
+        // We don't want to draw anything if there's nobody actually here
         if (summoner == null || participant == null) return;
         String role = participant.getRole();
         if (!role.equals("MEMBER") && !role.equals("LEADER")) return;
-        Dimension dimension = getSize();
-        int centeredX = dimension.width >> 1;
-        int centeredY = dimension.height >> 1;
-        FontMetrics metrics;
-        Graphics2D graphics2D = (Graphics2D) g;
-        graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        graphics2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        if (image != null) {
-            int imageX = centeredX - (image.getWidth() >> 1);
-            int imageY = (dimension.height >> 1) - (image.getHeight() >> 1);
-            g.setColor(Color.BLACK);
-            int imageSpacing = 3;
-            PaintHelper.roundedSquare(
-                    graphics2D,
-                    imageX - imageSpacing,
-                    imageY - imageSpacing,
-                    image.getWidth() + (imageSpacing << 1),
-                    image.getHeight() + (imageSpacing << 1),
-                    25, true, true, true, true
-            );
-            graphics2D.drawImage(PaintHelper.circleize(image, 25), imageX, imageY, null);
-        }
-        graphics2D.setFont(NAME_FONT);
-        metrics = graphics2D.getFontMetrics();
-        String name = summoner.getName().trim();
-        int width = metrics.stringWidth(name);
-        int nameX = centeredX - (width >> 1);
-        graphics2D.setColor(Color.WHITE);
-        graphics2D.drawString(name, nameX, centeredY - (IMAGE_DIMENSION.height >> 1) - 20);
-
         PartyMember member = (PartyMember) participant;
         if (member == null) return;
         PartyParticipantMetadata metadata = member.getParticipantMetadata();
         if (metadata == null) return;
-        graphics2D.setFont(ROLE_FONT);
-        int positionY = centeredY + (IMAGE_DIMENSION.height >> 1) + 40;
 
-        paintRoleSelection(graphics2D, centeredX, positionY, metadata.getPrimaryPreference(), 0);
-        paintRoleSelection(graphics2D, centeredX, positionY, metadata.getSecondaryPreference(), 1);
+        int centeredX = dimensions.width >> 1;
+        int centeredY = dimensions.height >> 1;
+        int positionY = centeredY + (IMAGE_DIMENSION.height >> 1) + 40;
+        g2d.setFont(ROLE_FONT);
+        paintRoleSelection(g2d, centeredX, positionY, metadata.getPrimaryPreference(), 0);
+        paintRoleSelection(g2d, centeredX, positionY, metadata.getSecondaryPreference(), 1);
     }
 
-    private void paintRoleSelection(Graphics2D graphics2D, int centeredX, int positionY, String role, int index) {
-        FontMetrics metrics = graphics2D.getFontMetrics();
-        graphics2D.setColor(Color.DARK_GRAY);
+    private void paintRoleSelection(Graphics2D g2d, int centeredX, int positionY, String role, int index) {
+        FontMetrics metrics = g2d.getFontMetrics();
+
+        g2d.setColor(Color.DARK_GRAY);
         int additionalSpacing = 5, gapSpacing = 6;
         int x = gapSpacing + (index * centeredX);
-        graphics2D.fillRoundRect(x, positionY - metrics.getAscent() - additionalSpacing, centeredX - (gapSpacing << 1), 18 + (additionalSpacing << 1), 10, 10);
         int primaryX = (centeredX - (index == 0 ? (centeredX >> 1) : (-1 * (centeredX >> 1)))) - (metrics.stringWidth(role) >> 1);
-        graphics2D.setColor(Color.WHITE);
-        graphics2D.drawString(role, primaryX, positionY);
+
+        g2d.fillRoundRect(x, positionY - metrics.getAscent() - additionalSpacing, centeredX - (gapSpacing << 1), 18 + (additionalSpacing << 1), 10, 10);
+        g2d.setColor(Color.WHITE);
+        g2d.drawString(role, primaryX, positionY);
     }
 
 }

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/DraftSummonerComponent.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/DraftSummonerComponent.java
@@ -2,7 +2,6 @@ package com.hawolt.ui.queue;
 
 import com.hawolt.client.resources.ledge.parties.objects.PartyMember;
 import com.hawolt.client.resources.ledge.parties.objects.PartyParticipantMetadata;
-import com.hawolt.util.paint.PaintHelper;
 
 import java.awt.*;
 

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -54,7 +54,6 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
     public GameLobby(Swiftrift swiftrift, Container parent, CardLayout layout, QueueWindow queueWindow) {
         super(new BorderLayout());
 
-        ChildUIComponent newButton = new ChildUIComponent(new BorderLayout());
         this.swiftrift = swiftrift;
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.PARTIES, this);
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.LOL_PLATFORM, this);
@@ -77,12 +76,9 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 throw new RuntimeException(e);
             }
         });
-        newButton.add(leave, BorderLayout.NORTH);
         close.addActionListener(listener -> {
             layout.show(parent, "modes");
         });
-        newButton.add(close, BorderLayout.CENTER);
-        add(newButton, BorderLayout.NORTH);
         invite.addActionListener(listener -> {
             String name = Swiftrift.showInputDialog("Who do you want to Invite?");
             if (name == null) return;
@@ -96,6 +92,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 Logger.error(e);
             }
         });
+        top.add(leave);
         top.add(close);
         top.add(invite);
         component.add(top, BorderLayout.NORTH);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -58,23 +58,8 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.PARTIES, this);
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.LOL_PLATFORM, this);
 
-        ChildUIComponent top = new ChildUIComponent(new GridLayout(0, 1, 0, 0));
-
-        LFlatButton invite = new LFlatButton("Invite another Summoner", LTextAlign.CENTER, HighlightType.COMPONENT);
-        LFlatButton leave = new LFlatButton("Leave Party", LTextAlign.CENTER, HighlightType.COMPONENT);
-        leave.addActionListener(listener -> {
-            this.stop.setEnabled(false);
-            this.start.setEnabled(true);
-            layout.show(parent, "modes");
-            try {
-                swiftrift.getLeagueClient().getLedge().getParties().role(PartyRole.DECLINED);
-                queueId = 0;
-                queueWindow.rebase();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        invite.addActionListener(listener -> {
+        LFlatButton inviteButton = new LFlatButton("Invite another Summoner", LTextAlign.CENTER, HighlightType.COMPONENT);
+        inviteButton.addActionListener(listener -> {
             String name = Swiftrift.showInputDialog("Who do you want to Invite?");
             if (name == null) return;
             LedgeEndpoint ledges = swiftrift.getLeagueClient().getLedge();
@@ -87,25 +72,33 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 Logger.error(e);
             }
         });
-        top.add(leave);
-        top.add(invite);
-        component.add(top, BorderLayout.NORTH);
-        Swiftrift.service.execute(() -> createSpecificComponents(component));
 
-        add(component, BorderLayout.CENTER);
-        ChildUIComponent bottom = new ChildUIComponent(new GridLayout(0, 2, 5, 0));
-        bottom.setBorder(new EmptyBorder(5, 5, 5, 5));
+        LFlatButton leavePartyButton = new LFlatButton("Leave Party", LTextAlign.CENTER, HighlightType.COMPONENT);
+        leavePartyButton.addActionListener(listener -> {
+            this.stop.setEnabled(false);
+            this.start.setEnabled(true);
+            layout.show(parent, "modes");
+            try {
+                swiftrift.getLeagueClient().getLedge().getParties().role(PartyRole.DECLINED);
+                queueId = 0;
+                queueWindow.rebase();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
         this.start = new LFlatButton("Start", LTextAlign.CENTER, HighlightType.COMPONENT);
-        start.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
-        start.setBackground(ColorPalette.buttonSelectionColor);
-        start.setHighlightColor(ColorPalette.buttonSelectionAltColor);
-        start.addActionListener(listener -> startQueue());
+        this.start.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
+        this.start.setBackground(ColorPalette.buttonSelectionColor);
+        this.start.setHighlightColor(ColorPalette.buttonSelectionAltColor);
+        this.start.addActionListener(listener -> startQueue());
+
         this.stop = new LFlatButton("×", LTextAlign.CENTER, HighlightType.COMPONENT);
-        stop.setEnabled(false);
-        stop.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
-        stop.setBackground(ColorPalette.buttonSelectionColor);
-        stop.setHighlightColor(ColorPalette.buttonSelectionAltColor);
-        stop.addActionListener(listener -> {
+        this.stop.setEnabled(false);
+        this.stop.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
+        this.stop.setBackground(ColorPalette.buttonSelectionColor);
+        this.stop.setHighlightColor(ColorPalette.buttonSelectionAltColor);
+        this.stop.addActionListener(listener -> {
             if (future != null) future.cancel(true);
             PartiesLedge partiesLedge = swiftrift.getLeagueClient().getLedge().getParties();
             PartiesRegistration registration = partiesLedge.getCurrentRegistration();
@@ -118,6 +111,16 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 Logger.error(e);
             }
         });
+
+        ChildUIComponent top = new ChildUIComponent(new GridLayout(0, 1, 0, 0));
+        top.add(leavePartyButton);
+        top.add(inviteButton);
+        component.add(top, BorderLayout.NORTH);
+        Swiftrift.service.execute(() -> createSpecificComponents(component));
+        add(component, BorderLayout.CENTER);
+        
+        ChildUIComponent bottom = new ChildUIComponent(new GridLayout(0, 2, 5, 0));
+        bottom.setBorder(new EmptyBorder(5, 5, 5, 5));
         bottom.add(stop);
         bottom.add(start);
         add(bottom, BorderLayout.SOUTH);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -138,7 +138,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
                 g.setColor(ColorPalette.cardColor);
-                PaintHelper.roundedSquare((Graphics2D) g, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
+                PaintHelper.roundedSquare(g2d, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
             }
         };
         lobbyChat.setPreferredSize(new Dimension(576, 192));

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -62,6 +62,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.LOL_PLATFORM, this);
 
         LFlatButton inviteButton = new LFlatButton("Invite another Summoner", LTextAlign.CENTER, HighlightType.COMPONENT);
+        inviteButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
         inviteButton.addActionListener(listener -> {
             String name = Swiftrift.showInputDialog("Who do you want to Invite?");
             if (name == null) return;
@@ -77,6 +78,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         });
 
         LFlatButton leavePartyButton = new LFlatButton("Leave Party", LTextAlign.CENTER, HighlightType.COMPONENT);
+        leavePartyButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
         leavePartyButton.addActionListener(listener -> {
             this.queueStopButton.setEnabled(false);
             this.queueStartButton.setEnabled(true);
@@ -136,7 +138,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 PaintHelper.roundedSquare((Graphics2D) g, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
             }
         };
-        lobbyChat.setPreferredSize(new Dimension(576, 224));
+        lobbyChat.setPreferredSize(new Dimension(576, 192));
         lobbyChat.setBorder(new EmptyBorder(8, 8, 8, 8));
         lobbyChat.add(new LTextPane("Chat goes here :)"));
 

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -48,7 +48,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
     public ScheduledFuture<?> future;
     public int queueId;
 
-    public ChildUIComponent component = new ChildUIComponent(new BorderLayout());
+    public ChildUIComponent component = new ChildUIComponent(new BorderLayout(8, 8));
     public ChildUIComponent grid;
     private LFlatButton queueStopButton, queueStartButton;
     private CurrentParty party;

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -47,7 +47,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
 
     public ChildUIComponent component = new ChildUIComponent(new BorderLayout());
     public ChildUIComponent grid;
-    private LFlatButton stop, start;
+    private LFlatButton queueStopButton, queueStartButton;
     private CurrentParty party;
     private String puuid;
 
@@ -75,8 +75,8 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
 
         LFlatButton leavePartyButton = new LFlatButton("Leave Party", LTextAlign.CENTER, HighlightType.COMPONENT);
         leavePartyButton.addActionListener(listener -> {
-            this.stop.setEnabled(false);
-            this.start.setEnabled(true);
+            this.queueStopButton.setEnabled(false);
+            this.queueStartButton.setEnabled(true);
             layout.show(parent, "modes");
             try {
                 swiftrift.getLeagueClient().getLedge().getParties().role(PartyRole.DECLINED);
@@ -87,18 +87,18 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
             }
         });
 
-        this.start = new LFlatButton("Start", LTextAlign.CENTER, HighlightType.COMPONENT);
-        this.start.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
-        this.start.setBackground(ColorPalette.buttonSelectionColor);
-        this.start.setHighlightColor(ColorPalette.buttonSelectionAltColor);
-        this.start.addActionListener(listener -> startQueue());
+        this.queueStartButton = new LFlatButton("Start", LTextAlign.CENTER, HighlightType.COMPONENT);
+        this.queueStartButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
+        this.queueStartButton.setBackground(ColorPalette.buttonSelectionColor);
+        this.queueStartButton.setHighlightColor(ColorPalette.buttonSelectionAltColor);
+        this.queueStartButton.addActionListener(listener -> startQueue());
 
-        this.stop = new LFlatButton("×", LTextAlign.CENTER, HighlightType.COMPONENT);
-        this.stop.setEnabled(false);
-        this.stop.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
-        this.stop.setBackground(ColorPalette.buttonSelectionColor);
-        this.stop.setHighlightColor(ColorPalette.buttonSelectionAltColor);
-        this.stop.addActionListener(listener -> {
+        this.queueStopButton = new LFlatButton("×", LTextAlign.CENTER, HighlightType.COMPONENT);
+        this.queueStopButton.setEnabled(false);
+        this.queueStopButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
+        this.queueStopButton.setBackground(ColorPalette.buttonSelectionColor);
+        this.queueStopButton.setHighlightColor(ColorPalette.buttonSelectionAltColor);
+        this.queueStopButton.addActionListener(listener -> {
             if (future != null) future.cancel(true);
             PartiesLedge partiesLedge = swiftrift.getLeagueClient().getLedge().getParties();
             PartiesRegistration registration = partiesLedge.getCurrentRegistration();
@@ -118,29 +118,29 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         component.add(top, BorderLayout.NORTH);
         Swiftrift.service.execute(() -> createSpecificComponents(component));
         add(component, BorderLayout.CENTER);
-        
+
         ChildUIComponent bottom = new ChildUIComponent(new GridLayout(0, 2, 5, 0));
         bottom.setBorder(new EmptyBorder(5, 5, 5, 5));
-        bottom.add(stop);
-        bottom.add(start);
+        bottom.add(queueStopButton);
+        bottom.add(queueStartButton);
         add(bottom, BorderLayout.SOUTH);
     }
 
-    public LFlatButton getStopButton() {
-        return stop;
+    public LFlatButton getQueueStopButton() {
+        return queueStopButton;
     }
 
-    public LFlatButton getStartButton() {
-        return start;
+    public LFlatButton getQueueStartButton() {
+        return queueStartButton;
     }
 
     public void toggleButtonState(boolean stop, boolean start) {
-        this.start.setEnabled(start);
-        this.stop.setEnabled(stop);
+        this.queueStartButton.setEnabled(start);
+        this.queueStopButton.setEnabled(stop);
     }
 
     public void flipButtonState() {
-        this.toggleButtonState(!stop.isEnabled(), !start.isEnabled());
+        this.toggleButtonState(!queueStopButton.isEnabled(), !queueStartButton.isEnabled());
     }
 
     protected abstract void createSpecificComponents(ChildUIComponent component);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -55,7 +55,7 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
     private String puuid;
 
     public GameLobby(Swiftrift swiftrift, Container parent, CardLayout layout, QueueWindow queueWindow) {
-        super(new BorderLayout());
+        super(new BorderLayout(8, 8));
 
         this.swiftrift = swiftrift;
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.PARTIES, this);
@@ -119,8 +119,11 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
             }
         });
 
-        ChildUIComponent top = new ChildUIComponent(new GridLayout(0, 1, 0, 0));
-        component.add(top, BorderLayout.NORTH);
+        LTextPane lobbyHeader = new LTextPane("Lobby Game Mode Here");
+        lobbyHeader.setFontSize(24);
+        lobbyHeader.setBackground(ColorPalette.backgroundColor);
+        this.add(lobbyHeader, BorderLayout.NORTH);
+
         Swiftrift.service.execute(() -> createSpecificComponents(component));
         add(component, BorderLayout.CENTER);
 

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -59,8 +59,6 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         this.swiftrift.getLeagueClient().getRMSClient().getHandler().addMessageServiceListener(MessageService.LOL_PLATFORM, this);
 
         ChildUIComponent top = new ChildUIComponent(new GridLayout(0, 1, 0, 0));
-        LFlatButton close = new LFlatButton("Choose mode", LTextAlign.CENTER, HighlightType.COMPONENT);
-        close.addActionListener(listener -> layout.show(parent, "modes"));
 
         LFlatButton invite = new LFlatButton("Invite another Summoner", LTextAlign.CENTER, HighlightType.COMPONENT);
         LFlatButton leave = new LFlatButton("Leave Party", LTextAlign.CENTER, HighlightType.COMPONENT);
@@ -76,9 +74,6 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
                 throw new RuntimeException(e);
             }
         });
-        close.addActionListener(listener -> {
-            layout.show(parent, "modes");
-        });
         invite.addActionListener(listener -> {
             String name = Swiftrift.showInputDialog("Who do you want to Invite?");
             if (name == null) return;
@@ -93,7 +88,6 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
             }
         });
         top.add(leave);
-        top.add(close);
         top.add(invite);
         component.add(top, BorderLayout.NORTH);
         Swiftrift.service.execute(() -> createSpecificComponents(component));

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -16,9 +16,12 @@ import com.hawolt.rms.data.subject.service.MessageService;
 import com.hawolt.rms.data.subject.service.RiotMessageServiceMessage;
 import com.hawolt.ui.generic.component.LFlatButton;
 import com.hawolt.ui.generic.component.LTextAlign;
+import com.hawolt.ui.generic.component.LTextPane;
 import com.hawolt.ui.generic.themes.ColorPalette;
 import com.hawolt.ui.generic.utility.ChildUIComponent;
 import com.hawolt.ui.generic.utility.HighlightType;
+import com.hawolt.util.paint.PaintHelper;
+
 import org.json.JSONObject;
 
 import javax.swing.border.EmptyBorder;
@@ -113,17 +116,39 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         });
 
         ChildUIComponent top = new ChildUIComponent(new GridLayout(0, 1, 0, 0));
-        top.add(leavePartyButton);
-        top.add(inviteButton);
         component.add(top, BorderLayout.NORTH);
         Swiftrift.service.execute(() -> createSpecificComponents(component));
         add(component, BorderLayout.CENTER);
 
-        ChildUIComponent bottom = new ChildUIComponent(new GridLayout(0, 2, 5, 0));
-        bottom.setBorder(new EmptyBorder(5, 5, 5, 5));
-        bottom.add(queueStopButton);
-        bottom.add(queueStartButton);
-        add(bottom, BorderLayout.SOUTH);
+        ChildUIComponent lobbyChat = new ChildUIComponent(new BorderLayout()){
+            @Override
+            protected void paintComponent(Graphics g) {
+                super.paintComponent(g);
+                Dimension dimensions = getSize();
+
+                // Enable anti-aliasing
+                Graphics2D g2d = (Graphics2D) g;
+                g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+                g.setColor(ColorPalette.cardColor);
+                PaintHelper.roundedSquare((Graphics2D) g, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
+            }
+        };
+        lobbyChat.setPreferredSize(new Dimension(576, 224));
+        lobbyChat.setBorder(new EmptyBorder(8, 8, 8, 8));
+        lobbyChat.add(new LTextPane("Chat goes here :)"));
+
+        ChildUIComponent lobbyControls = new ChildUIComponent(new GridLayout(0, 1, 8, 8));
+        lobbyControls.add(leavePartyButton);
+        lobbyControls.add(inviteButton);
+        lobbyControls.add(this.queueStopButton);
+        lobbyControls.add(this.queueStartButton);
+
+        ChildUIComponent bottom = new ChildUIComponent(new BorderLayout(8, 0));
+        bottom.add(lobbyChat, BorderLayout.WEST);
+        bottom.add(lobbyControls, BorderLayout.CENTER);
+
+        this.add(bottom, BorderLayout.SOUTH);
     }
 
     public LFlatButton getQueueStopButton() {

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/GameLobby.java
@@ -91,12 +91,14 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         });
 
         this.queueStartButton = new LFlatButton("Start", LTextAlign.CENTER, HighlightType.COMPONENT);
+        this.queueStartButton.setPreferredSize(new Dimension(192, 0));
         this.queueStartButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
         this.queueStartButton.setBackground(ColorPalette.buttonSelectionColor);
         this.queueStartButton.setHighlightColor(ColorPalette.buttonSelectionAltColor);
         this.queueStartButton.addActionListener(listener -> startQueue());
 
         this.queueStopButton = new LFlatButton("×", LTextAlign.CENTER, HighlightType.COMPONENT);
+        this.queueStopButton.setPreferredSize(new Dimension(192, 0));
         this.queueStopButton.setEnabled(false);
         this.queueStopButton.setRounding(ColorPalette.BUTTON_SMALL_ROUNDING);
         this.queueStopButton.setBackground(ColorPalette.buttonSelectionColor);
@@ -138,11 +140,14 @@ public abstract class GameLobby extends ChildUIComponent implements IServiceMess
         lobbyChat.setBorder(new EmptyBorder(8, 8, 8, 8));
         lobbyChat.add(new LTextPane("Chat goes here :)"));
 
+        ChildUIComponent queueButtons = new ChildUIComponent(new BorderLayout(8, 8));
+        queueButtons.add(this.queueStopButton, BorderLayout.CENTER);
+        queueButtons.add(this.queueStartButton, BorderLayout.EAST);
+
         ChildUIComponent lobbyControls = new ChildUIComponent(new GridLayout(0, 1, 8, 8));
         lobbyControls.add(leavePartyButton);
         lobbyControls.add(inviteButton);
-        lobbyControls.add(this.queueStopButton);
-        lobbyControls.add(this.queueStartButton);
+        lobbyControls.add(queueButtons);
 
         ChildUIComponent bottom = new ChildUIComponent(new BorderLayout(8, 0));
         bottom.add(lobbyChat, BorderLayout.WEST);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -268,7 +268,7 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
 
     public void showMatchMadeLobby(String mode) {
         this.currentMode = mode;
-        if (mode.equals("tft")) {
+        if (mode.toLowerCase().equals("tft")) {
             this.layout.show(parent, "tft");
         } else {
             DraftGameLobby draftGameLobby = (DraftGameLobby) relation.get("draft");

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -179,7 +179,10 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
                 super.paintComponent(g);
                 Dimension dimensions = getSize();
 
-                // TODO: Set anti-aliasing
+                // Enable anti-aliasing
+                Graphics2D g2d = (Graphics2D) g;
+                g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
                 g.setColor(ColorPalette.cardColor);
                 PaintHelper.roundedSquare((Graphics2D) g, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
             }

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -72,7 +72,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
     }};
 
     private final List<String> supportedModes = Arrays.asList("TUTORIAL", "ARAM", "BOTS", "BLIND", "DRAFT", "RANKED-FLEX", "RANKED-SOLO", "TFT");
-    private final ChildUIComponent main = new ChildUIComponent(new BorderLayout());
     private final Map<String, GameLobby> relation = new HashMap<>();
     private final CardLayout layout = new CardLayout();
     private final DraftGameLobby draftGameLobby;
@@ -148,7 +147,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
         constraints.gridy = 0;
         constraints.weightx = 1.0;
 
-        main.setBackground(ColorPalette.backgroundColor);
         for (String key : map.keySet()) {
             LLabel label = new LLabel(key, LTextAlign.CENTER, true);
             ChildUIComponent grid = new ChildUIComponent(new GridLayout(0, 1, 0, 4));

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -30,7 +30,6 @@ import com.hawolt.util.paint.PaintHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -44,32 +43,34 @@ import java.util.*;
  **/
 
 public class QueueWindow extends ChildUIComponent implements Runnable, PacketCallback, IServiceMessageListener<RiotMessageServiceMessage> {
-    private final Map<Integer, String> mapping = new HashMap<>() {{
-        //TFT
-        put(1090, "NORMAL");
-        put(1100, "RANKED");
-        put(1130, "HYPER ROLL");
-        put(1160, "DOUBLE UP");
+    private final Map<Integer, String> mapping = new HashMap<>() {
+        {
+            //TFT
+            put(1090, "NORMAL");
+            put(1100, "RANKED");
+            put(1130, "HYPER ROLL");
+            put(1160, "DOUBLE UP");
 
-        //TUTORIAL
-        put(2000, "TUTORIAL 1");
-        put(2010, "TUTORIAL 2");
-        put(2020, "TUTORIAL 3");
+            // TUTORIAL
+            put(2000, "TUTORIAL 1");
+            put(2010, "TUTORIAL 2");
+            put(2020, "TUTORIAL 3");
 
-        //ARAM
-        put(450, "ARAM");
+            // ARAM
+            put(450, "ARAM");
 
-        //BOT
-        put(830, "INTRO");
-        put(840, "EASY");
-        put(850, "INTERMEDIATE");
+            // BOT
+            put(830, "INTRO");
+            put(840, "EASY");
+            put(850, "INTERMEDIATE");
 
-        //NORMAL
-        put(430, "BLIND PICK");
-        put(420, "RANKED SOLO/DUO");
-        put(400, "DRAFT PICK");
-        put(440, "RANKED FLEX");
-    }};
+            // NORMAL
+            put(430, "BLIND PICK");
+            put(420, "RANKED SOLO/DUO");
+            put(400, "DRAFT PICK");
+            put(440, "RANKED FLEX");
+        }
+    };
 
     private final List<String> supportedModes = Arrays.asList("TUTORIAL", "ARAM", "BOTS", "BLIND", "DRAFT", "RANKED-FLEX", "RANKED-SOLO", "TFT");
     private final Map<String, GameLobby> relation = new HashMap<>();
@@ -256,9 +257,7 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
          * 1.   AFK_CHECK_FAILED
          */
         switch (info.getString("backwardsTransitionReason")) {
-            case "PLAYER_TIMED_OUT_ON_REQUIRED_ACTION",
-                    "PLAYER_LEFT_CHAMPION_SELECT",
-                    "PLAYER_LEFT_MATCHMAKING" -> {
+            case "PLAYER_TIMED_OUT_ON_REQUIRED_ACTION", "PLAYER_LEFT_CHAMPION_SELECT", "PLAYER_LEFT_MATCHMAKING" -> {
                 swiftrift.getLayoutManager().getChampSelectUI().showBlankPanel();
             }
         }
@@ -282,12 +281,7 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
         PartiesLedge partiesLedge = swiftrift.getLeagueClient().getLedge().getParties();
         try {
             partiesLedge.role(PartyRole.DECLINED);
-            partiesLedge.gamemode(
-                    partiesLedge.getCurrentPartyId(),
-                    maximumParticipantListSize,
-                    0,
-                    queueId
-            );
+            partiesLedge.gamemode(partiesLedge.getCurrentPartyId(), maximumParticipantListSize, 0, queueId);
             partiesLedge.partytype(PartyType.OPEN);
             showMatchMadeLobby(mode);
         } catch (IOException ex) {

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -82,7 +82,7 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
     private String currentMode;
 
     public QueueWindow(Swiftrift swiftrift) {
-        super(new BorderLayout());
+        super(new BorderLayout(8, 8));
         this.setBorder(new EmptyBorder(8, 8, 8, 8));
         this.swiftrift = swiftrift;
         this.add(parent = new ChildUIComponent(layout), BorderLayout.CENTER);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -72,7 +72,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
     }};
 
     private final List<String> supportedModes = Arrays.asList("TUTORIAL", "ARAM", "BOTS", "BLIND", "DRAFT", "RANKED-FLEX", "RANKED-SOLO", "TFT");
-    private final LFlatButton button = new LFlatButton("Show Lobby", LTextAlign.CENTER, HighlightType.COMPONENT);
     private final ChildUIComponent main = new ChildUIComponent(new BorderLayout());
     private final Map<String, GameLobby> relation = new HashMap<>();
     private final CardLayout layout = new CardLayout();
@@ -89,10 +88,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
         this.add(parent = new ChildUIComponent(layout), BorderLayout.CENTER);
         this.relation.put("draft", draftGameLobby = new DraftGameLobby(swiftrift, parent, layout, this));
         this.relation.put("tft", tftGameLobby = new TFTGameLobby(swiftrift, parent, layout, this));
-        this.button.addActionListener(listener -> layout.show(parent, currentMode));
-        this.button.setPreferredSize(new Dimension(getWidth() / 5, 30));
-        this.button.setHorizontalAlignment(SwingConstants.CENTER);
-        this.button.setVerticalAlignment(SwingConstants.CENTER);
         this.parent.add("draft", relation.get("draft"));
         this.parent.add("tft", relation.get("tft"));
         Swiftrift.service.execute(this);
@@ -285,7 +280,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
     public void createMatchMadeLobby(ActionEvent e, String mode) {
         JSONObject json = new JSONObject(e.getActionCommand());
         long queueId = json.getLong("id");
-        this.main.add(button, BorderLayout.SOUTH);
         long maximumParticipantListSize = json.getLong("maximumParticipantListSize");
         PartiesLedge partiesLedge = swiftrift.getLeagueClient().getLedge().getParties();
         try {
@@ -304,6 +298,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
     }
 
     public void rebase() {
-        main.remove(button);
+        // TODO: Show blank lobby section?
     }
 }

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/QueueWindow.java
@@ -158,7 +158,6 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
             LLabel label = new LLabel(key, LTextAlign.CENTER, true);
             ChildUIComponent grid = new ChildUIComponent(new GridLayout(0, 1, 0, 4));
             grid.setBackground(ColorPalette.cardColor);
-            parent.setBackground(ColorPalette.cardColor);
             grid.add(label);
 
             for (JSONObject object : map.get(key)) {
@@ -194,10 +193,9 @@ public class QueueWindow extends ChildUIComponent implements Runnable, PacketCal
         modesPanel.setBorder(new EmptyBorder(8, 8, 8, 8));
         modesPanel.setBackground(ColorPalette.backgroundColor);
         modesPanel.getVerticalScrollBar().setUnitIncrement(15);
+        modesPanel.setPreferredSize(new Dimension(300, 0));
 
-        main.add(modesPanel, BorderLayout.CENTER);
-        this.parent.add("modes", main);
-        layout.show(parent, "modes");
+        this.add(modesPanel, BorderLayout.WEST);
         revalidate();
     }
 

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/SummonerComponent.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/SummonerComponent.java
@@ -51,35 +51,42 @@ public class SummonerComponent extends ChildUIComponent implements ResourceConsu
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
+        Dimension dimensions = getSize();
+        Graphics2D g2d = (Graphics2D) g;
+
+        // We don't want to draw anything if there's nobody actually here
         if (summoner == null || participant == null) return;
         String role = participant.getRole();
         if (!role.equals("MEMBER") && !role.equals("LEADER")) return;
-        Dimension dimension = getSize();
-        Graphics2D graphics2D = (Graphics2D) g;
-        graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        graphics2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        graphics2D.setColor(Color.BLACK);
-        PaintHelper.roundedSquare(graphics2D, 2, 2, dimension.width - 5, dimension.height - 5, 25, true, true, true, true);
-        graphics2D.setColor(accent);
-        PaintHelper.roundedSquare(graphics2D, 3, 3, dimension.width - 7, dimension.height - 7, 25, true, true, true, true);
-        int centeredX = dimension.width >> 1;
-        int centeredY = dimension.height >> 1;
+
+        // Enable antialisaing
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+        // Draw main card
+        g.setColor(ColorPalette.cardColor);
+        PaintHelper.roundedSquare(g2d, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
+        
+        // Draw icon
+        int centeredX = dimensions.width >> 1;
+        int centeredY = dimensions.height >> 1;
         if (image != null) {
-            int imageX = centeredX - (image.getWidth() >> 1);
-            int imageY = (dimension.height >> 1) - (image.getHeight() >> 1);
-            g.setColor(Color.BLACK);
-            int imageSpacing = 3;
-            g.fillRect(
-                    imageX - imageSpacing,
-                    imageY - imageSpacing,
-                    image.getWidth() + (imageSpacing << 1),
-                    image.getHeight() + (imageSpacing << 1)
-            );
-            g.drawImage(image, imageX, imageY, null);
+            int imageW = image.getWidth();
+            int imageH = image.getHeight();
+            int imageX = centeredX - (imageW >> 1);
+            int imageY = (dimensions.height >> 1) - (imageH >> 1);
+
+            // Placeholder background in case something funky is happening with the image
+            g.setColor(ColorPalette.backgroundColor);
+            PaintHelper.roundedSquare(g2d, imageX, imageY, imageW, imageH, ColorPalette.CARD_ROUNDING, true, true, true, true);
+
+            // Main icon
+            g.drawImage(PaintHelper.circleize(image, ColorPalette.CARD_ROUNDING), imageX, imageY, null);
         }
-        FontMetrics metrics;
-        graphics2D.setFont(NAME_FONT);
-        metrics = graphics2D.getFontMetrics();
+
+        g2d.setFont(NAME_FONT);
+        g2d.setColor(Color.WHITE);
+        FontMetrics metrics = g2d.getFontMetrics();
         String name = summoner.getName().trim();
         int width = metrics.stringWidth(name);
         int nameX = centeredX - (width >> 1);

--- a/SwingUI/src/main/java/com/hawolt/ui/queue/SummonerComponent.java
+++ b/SwingUI/src/main/java/com/hawolt/ui/queue/SummonerComponent.java
@@ -66,8 +66,8 @@ public class SummonerComponent extends ChildUIComponent implements ResourceConsu
         // Draw main card
         g.setColor(ColorPalette.cardColor);
         PaintHelper.roundedSquare(g2d, 0, 0, dimensions.width, dimensions.height, ColorPalette.CARD_ROUNDING, true, true, true, true);
-        
-        // Draw icon
+
+        // Draw summoner icon
         int centeredX = dimensions.width >> 1;
         int centeredY = dimensions.height >> 1;
         if (image != null) {
@@ -84,6 +84,7 @@ public class SummonerComponent extends ChildUIComponent implements ResourceConsu
             g.drawImage(PaintHelper.circleize(image, ColorPalette.CARD_ROUNDING), imageX, imageY, null);
         }
 
+        // Summoner name
         g2d.setFont(NAME_FONT);
         g2d.setColor(Color.WHITE);
         FontMetrics metrics = g2d.getFontMetrics();
@@ -92,6 +93,11 @@ public class SummonerComponent extends ChildUIComponent implements ResourceConsu
         int nameX = centeredX - (width >> 1);
         g.drawString(name, nameX, centeredY - (IMAGE_DIMENSION.height >> 1) - 20);
 
+        // Draw leader indicator
+        if (role.equals("LEADER")){
+            g2d.setColor(Color.ORANGE);
+            g.drawString("P", 8, 8 + metrics.getAscent());
+        }
     }
 
 


### PR DESCRIPTION
![image](https://github.com/hawolt/SwiftRift/assets/22003655/33e45975-285c-40f2-8589-3a9f5e0439ca)

Todo:
- [ ] Show the current lobby game mode
- [ ] Make the game mode list more readable/better separation of the different types of game mode
- [ ] Make the role indicator on summoner cards less crappy
- [ ] Show summoner levels
- [ ] Stop long summoner names from overflowing
- [ ] Disable queue start/stop buttons if you're not the party leader